### PR TITLE
chore(deps): bump tailwindcss from 4.2.1 to 4.2.2 in /frontend (#632)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,7 @@
         "swr": "^2.3.3",
         "systeminformation": "^5.31.6",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.0.12",
+        "tailwindcss": "^4.2.2",
         "tailwindcss-animate": "^1.0.7",
         "tar-fs": "^3.1.1",
         "vaul": "^1.1.2",
@@ -4785,6 +4785,12 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
@@ -5083,6 +5089,12 @@
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
       }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
@@ -15115,9 +15127,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,7 @@
     "swr": "^2.3.3",
     "systeminformation": "^5.31.6",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.0.12",
+    "tailwindcss": "^4.2.2",
     "tailwindcss-animate": "^1.0.7",
     "tar-fs": "^3.1.1",
     "vaul": "^1.1.2",


### PR DESCRIPTION
chore(deps): bump tailwindcss from 4.2.1 to 4.2.2 in /frontend (#632)