### PR TITLE
chore(deps): bump idna from 3.11 to 3.15 in /workers/custom-application-profiling in the pip group across 1 directory (#658)

### DIFF
--- a/workers/custom-application-profiling/requirements.txt
+++ b/workers/custom-application-profiling/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.4.4
 click==8.3.1
 fastapi==0.135.3
 h11==0.16.0
-idna==3.11
+idna==3.15
 psutil==7.1.0
 pydantic==2.12.5
 pydantic_core==2.41.5


### PR DESCRIPTION
chore(deps): bump idna from 3.11 to 3.15 in /workers/custom-application-profiling in the pip group across 1 directory (#658)